### PR TITLE
Changed code to create serializer instance everytime formatter is cal…

### DIFF
--- a/src/WebApi.Hal/JsonHalMediaTypeOutputFormatter.cs
+++ b/src/WebApi.Hal/JsonHalMediaTypeOutputFormatter.cs
@@ -49,7 +49,10 @@ namespace WebApi.Hal
             SerializerSettings.Converters.Add(_embeddedResourceConverter);
             SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
         }
-
+        protected override JsonSerializer CreateJsonSerializer()
+        {
+            return JsonSerializer.Create(this.SerializerSettings);
+        }
         #endregion
     }
 }

--- a/src/WebApi.Hal/project.json
+++ b/src/WebApi.Hal/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rc2-3",
+  "version": "1.0.0-rc2-4",
   "description": "WebApi.Hal",
   "authors": [ "Jake Ginnivan" ],
   "packOptions": {


### PR DESCRIPTION
…led. singleton instance of serializer created problem because ResourceConverter was removing itself from the list of converters during serializing. So another call to serialize a resource returned null because it could not find a converter which can convert it.
